### PR TITLE
Fix for broken zlib URL

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+zlib,http://zlib.net/fossils/zlib-1.2.11.tar.gz
 statgen/savvy@019a1ddaa9ec588f807f234f68787862f94ea057
 statgen/libStatGen@cram-support --cmake dep/libstatgen.cmake
 atks/Rmath@1a438f2f363e1f8fcf6b2804bd2cd0136d300230 --cmake dep/rmath.cmake


### PR DESCRIPTION
zlib v1.2.11 has been archived to a new location. This fix installs zlib using the new URL, which prevents the shrinkwrap package from trying to install the old URL. 